### PR TITLE
Fix: prevent page reset when rating, updating status, or deleting books

### DIFF
--- a/src/app/my-books/page.tsx
+++ b/src/app/my-books/page.tsx
@@ -58,8 +58,11 @@ export default function MyBooksPage() {
 
   useEffect(() => {
     filterAndSortBooks();
-    setCurrentPage(1); // Reset to page 1 when filters change
   }, [userBooks, selectedShelf, searchTerm, sortBy]);
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [selectedShelf, searchTerm, sortBy]);
 
   const fetchUserBooks = async () => {
     try {


### PR DESCRIPTION
Split useEffect to separate filtering from page reset logic. Page now only resets to 1 when user intentionally changes shelf/search/sort, not when modifying book data (rating, status updates, deletes).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix pagination UX so the My Books page doesn’t jump to page 1 when rating, updating status, or deleting a book. It now only resets to page 1 when changing shelf, search, or sort.

<sup>Written for commit 4aa9ed61efd7cf53efdc7d8ddd689ff969ba0a1d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

