### PR TITLE
Fixes: #8 Fix filter dropdown visibility by adding text and background colors

### DIFF
--- a/src/app/my-books/page.tsx
+++ b/src/app/my-books/page.tsx
@@ -328,7 +328,7 @@ export default function MyBooksPage() {
           <select
             value={sortBy}
             onChange={(e) => setSortBy(e.target.value)}
-            className="px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#018283] focus:border-transparent"
+            className="px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#018283] focus:border-transparent text-gray-900 bg-white"
           >
             <option value="date-added">Recently Added</option>
             <option value="title">Title A-Z</option>
@@ -337,7 +337,7 @@ export default function MyBooksPage() {
           <select
             value={itemsPerPage}
             onChange={(e) => handleItemsPerPageChange(Number(e.target.value))}
-            className="px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#018283] focus:border-transparent"
+            className="px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#018283] focus:border-transparent text-gray-900 bg-white"
           >
             <option value={10}>10 per page</option>
             <option value={25}>25 per page</option>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes #8 by improving filter dropdown visibility on the My Books page: set explicit text-gray-900 and white background on the Sort by and Items per page selects to ensure readable text.

<sup>Written for commit e88f82d6fac92a386d921759277bc26718b3dc18. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

