### PR TITLE
Fix UX: prevent page reset when rating, updating status, or deleting …

### DIFF
--- a/src/app/my-books/page.tsx
+++ b/src/app/my-books/page.tsx
@@ -58,8 +58,11 @@ export default function MyBooksPage() {
 
   useEffect(() => {
     filterAndSortBooks();
-    setCurrentPage(1); // Reset to page 1 when filters change
   }, [userBooks, selectedShelf, searchTerm, sortBy]);
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [selectedShelf, searchTerm, sortBy]);
 
   const fetchUserBooks = async () => {
     try {


### PR DESCRIPTION
…books

Split useEffect to separate filtering from page reset logic. Now page only resets to 1 when user intentionally changes shelf/search/sort, not when modifying book data.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent unwanted pagination reset on My Books when editing a book (rating, status, delete). The page now only resets to 1 when shelf, search, or sort change, by splitting filtering and reset into separate effects.

<sup>Written for commit fd8d3ff9173e6b0426f5e8f91c2c568bc285beb4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

