### PR TITLE
Add Book Search History (#2)

### DIFF
--- a/src/app/api/search-history/route.ts
+++ b/src/app/api/search-history/route.ts
@@ -1,0 +1,195 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+
+export async function GET(request: NextRequest) {
+  try {
+    const authHeader = request.headers.get('authorization');
+    if (!authHeader?.startsWith('Bearer ')) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const token = authHeader.slice(7);
+    const supabase = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      { global: { headers: { Authorization: `Bearer ${token}` } } }
+    );
+
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    // Check if search history is enabled for this user
+    const { data: userData } = await supabase
+      .from('users')
+      .select('search_history_enabled')
+      .eq('id', user.id)
+      .single();
+
+    if (userData && userData.search_history_enabled === false) {
+      return NextResponse.json({ searches: [] });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const limit = parseInt(searchParams.get('limit') || '10');
+
+    const { data: searches, error } = await supabase
+      .from('search_history')
+      .select('id, query, searched_at')
+      .eq('user_id', user.id)
+      .order('searched_at', { ascending: false })
+      .limit(limit);
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+
+    return NextResponse.json({ searches: searches || [] });
+  } catch (error) {
+    console.error('Search history GET error:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const authHeader = request.headers.get('authorization');
+    if (!authHeader?.startsWith('Bearer ')) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const token = authHeader.slice(7);
+    const supabase = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      { global: { headers: { Authorization: `Bearer ${token}` } } }
+    );
+
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { query } = await request.json();
+
+    // Validation
+    if (!query || typeof query !== 'string') {
+      return NextResponse.json({ error: 'Query is required' }, { status: 400 });
+    }
+
+    const trimmedQuery = query.trim();
+    if (trimmedQuery.length === 0) {
+      return NextResponse.json({ error: 'Query cannot be empty' }, { status: 400 });
+    }
+
+    if (trimmedQuery.length > 200) {
+      return NextResponse.json({ error: 'Query is too long (max 200 characters)' }, { status: 400 });
+    }
+
+    // Check if search history is enabled for this user
+    const { data: userData } = await supabase
+      .from('users')
+      .select('search_history_enabled')
+      .eq('id', user.id)
+      .single();
+
+    if (userData && userData.search_history_enabled === false) {
+      // Silent no-op when disabled - return success without saving
+      return NextResponse.json({
+        search: {
+          id: 'skipped',
+          query: trimmedQuery,
+          searched_at: new Date().toISOString()
+        }
+      });
+    }
+
+    // Upsert: Update searched_at if query exists, insert if new
+    const { data: search, error: upsertError } = await supabase
+      .from('search_history')
+      .upsert(
+        {
+          user_id: user.id,
+          query: trimmedQuery,
+          searched_at: new Date().toISOString(),
+        },
+        { onConflict: 'user_id,query' }
+      )
+      .select('id, query, searched_at')
+      .single();
+
+    if (upsertError) {
+      console.error('Error saving search history:', upsertError);
+      return NextResponse.json({ error: upsertError.message }, { status: 400 });
+    }
+
+    // Auto-prune: Keep only last 50 searches per user
+    const { data: allSearches } = await supabase
+      .from('search_history')
+      .select('id')
+      .eq('user_id', user.id)
+      .order('searched_at', { ascending: false });
+
+    if (allSearches && allSearches.length > 50) {
+      const idsToKeep = allSearches.slice(0, 50).map(s => s.id);
+      await supabase
+        .from('search_history')
+        .delete()
+        .eq('user_id', user.id)
+        .not('id', 'in', `(${idsToKeep.join(',')})`);
+    }
+
+    return NextResponse.json({ search });
+  } catch (error) {
+    console.error('Search history POST error:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(request: NextRequest) {
+  try {
+    const authHeader = request.headers.get('authorization');
+    if (!authHeader?.startsWith('Bearer ')) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const token = authHeader.slice(7);
+    const supabase = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      { global: { headers: { Authorization: `Bearer ${token}` } } }
+    );
+
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { error } = await supabase
+      .from('search_history')
+      .delete()
+      .eq('user_id', user.id);
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+
+    return NextResponse.json({
+      success: true,
+      message: 'Search history cleared'
+    });
+  } catch (error) {
+    console.error('Search history DELETE error:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/users/profile/route.ts
+++ b/src/app/api/users/profile/route.ts
@@ -21,11 +21,11 @@ export async function PATCH(request: NextRequest) {
     }
 
     const body = await request.json()
-    const { username, currentPassword, newPassword } = body
+    const { username, currentPassword, newPassword, searchHistoryEnabled } = body
 
-    if (!username && !newPassword) {
+    if (!username && !newPassword && searchHistoryEnabled === undefined) {
       return NextResponse.json(
-        { error: 'Please provide username or new password' },
+        { error: 'Please provide username, new password, or preference to update' },
         { status: 400 }
       )
     }
@@ -89,6 +89,28 @@ export async function PATCH(request: NextRequest) {
         console.error('Username update error:', updateError)
         return NextResponse.json(
           { error: 'Failed to update username' },
+          { status: 500 }
+        )
+      }
+    }
+
+    if (searchHistoryEnabled !== undefined) {
+      if (typeof searchHistoryEnabled !== 'boolean') {
+        return NextResponse.json(
+          { error: 'searchHistoryEnabled must be a boolean' },
+          { status: 400 }
+        )
+      }
+
+      const { error: updateError } = await supabase
+        .from('users')
+        .update({ search_history_enabled: searchHistoryEnabled })
+        .eq('id', user.id)
+
+      if (updateError) {
+        console.error('Search history preference update error:', updateError)
+        return NextResponse.json(
+          { error: 'Failed to update search history preference' },
           { status: 500 }
         )
       }

--- a/src/app/discover/page.tsx
+++ b/src/app/discover/page.tsx
@@ -28,6 +28,12 @@ interface FilterOptions {
   yearRange: string;
 }
 
+interface SearchHistory {
+  id: string;
+  query: string;
+  searched_at: string;
+}
+
 export default function DiscoverPage() {
   const searchParams = useSearchParams();
   const query = searchParams.get('q') || '';
@@ -44,6 +50,8 @@ export default function DiscoverPage() {
   const [userBooks, setUserBooks] = useState<{ [key: string]: string }>({});
   const [timeframe, setTimeframe] = useState('all');
   const [searchError, setSearchError] = useState('');
+  const [searchHistory, setSearchHistory] = useState<SearchHistory[]>([]);
+  const [showSearchHistory, setShowSearchHistory] = useState(false);
   const { user } = useAuth();
   const debounceTimer = useRef<NodeJS.Timeout | null>(null);
 
@@ -116,10 +124,50 @@ export default function DiscoverPage() {
       }
 
       setBooks(data.books || []);
+
+      // Save search query to history
+      if (query && user) {
+        await saveSearchQuery(query);
+      }
     } catch (error) {
       console.error('Search error:', error);
     } finally {
       setLoading(false);
+    }
+  };
+
+  const fetchSearchHistory = async () => {
+    if (!user) return;
+
+    try {
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session?.access_token) return;
+
+      const response = await fetch('/api/search-history?limit=10', {
+        headers: { 'Authorization': `Bearer ${session.access_token}` }
+      });
+      const data = await response.json();
+      setSearchHistory(data.searches || []);
+    } catch (error) {
+      console.error('Failed to fetch search history:', error);
+    }
+  };
+
+  const saveSearchQuery = async (query: string) => {
+    try {
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session?.access_token) return;
+
+      await fetch('/api/search-history', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${session.access_token}`
+        },
+        body: JSON.stringify({ query })
+      });
+    } catch (error) {
+      console.error('Failed to save search history:', error);
     }
   };
 
@@ -320,6 +368,7 @@ export default function DiscoverPage() {
                    onChange={(e) => {
                      setInputValue(e.target.value);
                      setSearchError('');
+                     setShowSearchHistory(false);
 
                      if (debounceTimer.current) {
                        clearTimeout(debounceTimer.current);
@@ -340,6 +389,15 @@ export default function DiscoverPage() {
                        setSearchError('Please enter a search term');
                        e.preventDefault();
                      }
+                   }}
+                   onFocus={() => {
+                     if (!inputValue && user) {
+                       fetchSearchHistory();
+                       setShowSearchHistory(true);
+                     }
+                   }}
+                   onBlur={() => {
+                     setTimeout(() => setShowSearchHistory(false), 200);
                    }}
                    placeholder="Search for books, authors, or ISBN..."
                    className="flex-1 px-4 py-5 text-lg bg-transparent focus:outline-none placeholder-gray-400 text-gray-900"
@@ -392,6 +450,34 @@ export default function DiscoverPage() {
                <div className="mt-3 text-sm text-red-600 flex items-center gap-2">
                  <span>⚠️</span>
                  <span>{searchError}</span>
+               </div>
+             )}
+
+             {/* Search History Dropdown */}
+             {showSearchHistory && searchHistory.length > 0 && !inputValue && (
+               <div className="absolute top-full left-0 right-0 mt-2 bg-white border border-gray-200 rounded-2xl shadow-xl z-10 overflow-hidden">
+                 <div className="p-4">
+                   <div className="flex items-center justify-between mb-3">
+                     <h3 className="text-sm font-semibold text-gray-700">Recent Searches</h3>
+                   </div>
+                   <div className="space-y-1">
+                     {searchHistory.map((search) => (
+                       <button
+                         key={search.id}
+                         onClick={async () => {
+                           await saveSearchQuery(search.query);
+                           window.location.href = `/discover?q=${encodeURIComponent(search.query)}`;
+                         }}
+                         className="w-full text-left px-3 py-2.5 text-sm text-gray-700 hover:bg-gray-50 rounded-lg transition-colors flex items-center justify-between group"
+                       >
+                         <div className="flex items-center flex-1">
+                           <Search className="h-4 w-4 text-gray-400 mr-3 group-hover:text-[#018283]" />
+                           <span className="group-hover:text-[#018283]">{search.query}</span>
+                         </div>
+                       </button>
+                     ))}
+                   </div>
+                 </div>
                </div>
              )}
            </div>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -25,6 +25,8 @@ export default function Settings() {
   const { user, loading: authLoading, signOut } = useAuth();
   const { currentTheme, setTheme } = useTheme();
   const [emailNotifications, setEmailNotifications] = useState(true);
+  const [searchHistoryEnabled, setSearchHistoryEnabled] = useState(true);
+  const [clearHistoryLoading, setClearHistoryLoading] = useState(false);
   const [showSaved, setShowSaved] = useState(false);
   const [accountForm, setAccountForm] = useState<AccountFormState>({
     username: '',
@@ -69,6 +71,60 @@ export default function Settings() {
      localStorage.setItem('emailNotifications', enabled.toString());
      setShowSaved(true);
      setTimeout(() => setShowSaved(false), 2000);
+   };
+
+   const handleSearchHistoryToggle = async (enabled: boolean) => {
+     setSearchHistoryEnabled(enabled);
+
+     try {
+       const { data: { session } } = await (await import('@/lib/supabase/client')).supabase.auth.getSession();
+       const token = session?.access_token;
+
+       if (!token) return;
+
+       await fetch('/api/users/profile', {
+         method: 'PATCH',
+         headers: {
+           'Content-Type': 'application/json',
+           'Authorization': `Bearer ${token}`
+         },
+         body: JSON.stringify({ searchHistoryEnabled: enabled })
+       });
+
+       setShowSaved(true);
+       setTimeout(() => setShowSaved(false), 2000);
+     } catch (error) {
+       console.error('Failed to update search history preference:', error);
+       setSearchHistoryEnabled(!enabled); // Revert on error
+     }
+   };
+
+   const handleClearHistory = async () => {
+     if (!confirm('Are you sure you want to clear all search history? This cannot be undone.')) {
+       return;
+     }
+
+     setClearHistoryLoading(true);
+     try {
+       const { data: { session } } = await (await import('@/lib/supabase/client')).supabase.auth.getSession();
+       const token = session?.access_token;
+
+       if (!token) return;
+
+       const response = await fetch('/api/search-history', {
+         method: 'DELETE',
+         headers: { 'Authorization': `Bearer ${token}` }
+       });
+
+       if (response.ok) {
+         alert('Search history cleared successfully');
+       }
+     } catch (error) {
+       console.error('Failed to clear history:', error);
+       alert('Failed to clear search history');
+     } finally {
+       setClearHistoryLoading(false);
+     }
    };
 
     const handleSignOut = async () => {
@@ -323,6 +379,41 @@ export default function Settings() {
                  />
                </button>
              </div>
+
+             <div className="flex items-center justify-between pb-6 border-b border-gray-200">
+               <div>
+                 <h3 className="font-semibold text-gray-900">Search History</h3>
+                 <p className="text-sm text-gray-600 mt-1">Save your search queries for quick access</p>
+               </div>
+               <button
+                 onClick={() => handleSearchHistoryToggle(!searchHistoryEnabled)}
+                 className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+                   searchHistoryEnabled ? 'bg-teal-600' : 'bg-gray-300'
+                 }`}
+               >
+                 <span
+                   className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                     searchHistoryEnabled ? 'translate-x-6' : 'translate-x-1'
+                   }`}
+                 />
+               </button>
+             </div>
+
+             {searchHistoryEnabled && (
+               <div className="pb-6 border-b border-gray-200">
+                 <h3 className="font-semibold text-gray-900 mb-2">Clear Search History</h3>
+                 <p className="text-sm text-gray-600 mb-4">
+                   Permanently delete all saved searches
+                 </p>
+                 <button
+                   onClick={handleClearHistory}
+                   disabled={clearHistoryLoading}
+                   className="px-4 py-2 border border-red-300 text-red-600 rounded-lg hover:bg-red-50 transition-colors font-medium disabled:opacity-50"
+                 >
+                   {clearHistoryLoading ? 'Clearing...' : 'Clear All Searches'}
+                 </button>
+               </div>
+             )}
 
              {showSaved && (
                <div className="p-3 bg-green-50 border border-green-200 rounded-lg flex items-center gap-2 text-green-700 text-sm">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -6,11 +6,19 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { BookOpen, Search, LogOut, X, LayoutDashboard, Compass, User, Users, Library, Settings, Upload } from 'lucide-react';
 
+interface SearchHistory {
+  id: string;
+  query: string;
+  searched_at: string;
+}
+
 export default function Header() {
   const { user, signOut, loading: authLoading } = useAuth();
   const [showSearch, setShowSearch] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [showUserMenu, setShowUserMenu] = useState(false);
+  const [searchHistory, setSearchHistory] = useState<SearchHistory[]>([]);
+  const [historyLoading, setHistoryLoading] = useState(false);
   const searchRef = useRef<HTMLDivElement>(null);
   const userMenuRef = useRef<HTMLDivElement>(null);
   const pathname = usePathname();
@@ -36,6 +44,50 @@ export default function Header() {
     document.addEventListener('mousedown', handleClickOutside);
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
+
+  useEffect(() => {
+    if (showSearch && user) {
+      fetchSearchHistory();
+    }
+  }, [showSearch, user]);
+
+  const fetchSearchHistory = async () => {
+    setHistoryLoading(true);
+    try {
+      const { supabase } = await import('@/lib/supabase/client');
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session?.access_token) return;
+
+      const response = await fetch('/api/search-history?limit=5', {
+        headers: { 'Authorization': `Bearer ${session.access_token}` }
+      });
+      const data = await response.json();
+      setSearchHistory(data.searches || []);
+    } catch (error) {
+      console.error('Failed to fetch search history:', error);
+    } finally {
+      setHistoryLoading(false);
+    }
+  };
+
+  const saveSearchQuery = async (query: string) => {
+    try {
+      const { supabase } = await import('@/lib/supabase/client');
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session?.access_token) return;
+
+      await fetch('/api/search-history', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${session.access_token}`
+        },
+        body: JSON.stringify({ query })
+      });
+    } catch (error) {
+      console.error('Failed to save search history:', error);
+    }
+  };
 
   if (authLoading || !user || pathname === '/' || pathname.startsWith('/auth/')) {
     return null;
@@ -235,15 +287,16 @@ export default function Header() {
                     placeholder="Search for books, authors, or ISBN..."
                     value={searchQuery}
                     onChange={(e) => setSearchQuery(e.target.value)}
-                    onKeyDown={(e) => {
+                    onKeyDown={async (e) => {
                       if (e.key === 'Enter' && searchQuery.trim()) {
+                        await saveSearchQuery(searchQuery.trim());
                         window.location.href = `/discover?q=${encodeURIComponent(searchQuery.trim())}`;
                       }
                     }}
                     autoFocus
                     className="
-                      w-full pl-12 pr-4 py-3 
-                      border border-gray-200 rounded-xl 
+                      w-full pl-12 pr-4 py-3
+                      border border-gray-200 rounded-xl
                       focus:outline-none focus:ring-2 focus:ring-[#018283]/20 focus:border-[#018283]
                       bg-gray-50/50 focus:bg-white
                       transition-all duration-200
@@ -265,6 +318,32 @@ export default function Header() {
                   <X className="h-5 w-5" />
                 </button>
               </div>
+
+              {!searchQuery && searchHistory.length > 0 && (
+                <div className="mt-4">
+                  <h3 className="text-sm font-medium text-gray-700 mb-2">Recent Searches</h3>
+                  <div className="space-y-1">
+                    {searchHistory.map((search) => (
+                      <button
+                        key={search.id}
+                        onClick={async () => {
+                          await saveSearchQuery(search.query);
+                          window.location.href = `/discover?q=${encodeURIComponent(search.query)}`;
+                        }}
+                        className="w-full text-left px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 rounded-lg transition-colors flex items-center group"
+                      >
+                        <Search className="h-4 w-4 text-gray-400 mr-2 group-hover:text-[#018283]" />
+                        <span className="group-hover:text-[#018283]">{search.query}</span>
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {!searchQuery && searchHistory.length === 0 && !historyLoading && (
+                <p className="mt-4 text-sm text-gray-500">No recent searches</p>
+              )}
+
               <p className="text-xs text-gray-500 mt-3 flex items-center">
                 <kbd className="px-2 py-1 bg-gray-100 border border-gray-200 rounded text-xs font-mono mr-2">Enter</kbd>
                 to search

--- a/supabase/migrations/011_create_search_history.sql
+++ b/supabase/migrations/011_create_search_history.sql
@@ -1,0 +1,25 @@
+-- Create search_history table to store user search queries
+CREATE TABLE IF NOT EXISTS public.search_history (
+  id TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  query TEXT NOT NULL,
+  searched_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  UNIQUE(user_id, query)
+);
+
+-- Create indexes for efficient querying
+CREATE INDEX IF NOT EXISTS idx_search_history_user_id ON public.search_history(user_id);
+CREATE INDEX IF NOT EXISTS idx_search_history_user_searched_at ON public.search_history(user_id, searched_at DESC);
+
+-- Enable Row Level Security
+ALTER TABLE public.search_history ENABLE ROW LEVEL SECURITY;
+
+-- RLS Policies
+CREATE POLICY "Users can view their own search history" ON public.search_history
+  FOR SELECT USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert their own search history" ON public.search_history
+  FOR INSERT WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete their own search history" ON public.search_history
+  FOR DELETE USING (auth.uid() = user_id);

--- a/supabase/migrations/012_add_search_history_enabled.sql
+++ b/supabase/migrations/012_add_search_history_enabled.sql
@@ -1,0 +1,3 @@
+-- Add search_history_enabled preference to users table
+ALTER TABLE public.users
+ADD COLUMN IF NOT EXISTS search_history_enabled BOOLEAN DEFAULT true;


### PR DESCRIPTION
## Summary
Implements issue #2 - Add Book Search History feature with database storage, privacy controls, and UI integration.

## Features Implemented
- ✅ Store past book search queries for each user
- ✅ Display recent searches on the search screen (Header & Discover page)
- ✅ Allow users to clear their search history
- ✅ Provide a toggle to enable/disable search history
- ✅ Empty state message if no history exists
- ✅ Privacy controls: opt-out capability and easy deletion

## Database Changes
- **New table**: `search_history` with RLS policies for user isolation
- **User preference**: `search_history_enabled` column in `users` table
- **Auto-pruning**: Keeps only last 50 searches per user

## API Endpoints
- `GET /api/search-history` - Fetch user's recent searches with limit parameter
- `POST /api/search-history` - Save search queries (silent no-op when disabled)
- `DELETE /api/search-history` - Clear all user's search history
- `PATCH /api/users/profile` - Updated to handle search history preference

## UI Changes
- **Header Component**: Shows 5 most recent searches in search overlay
- **Discover Page**: Shows 10 recent searches when search input is focused (empty)
- **Settings Page**: Toggle to enable/disable + clear all history button

## Privacy & Security
- Row Level Security (RLS) policies ensure users can only access their own searches
- User can disable search history tracking in Settings
- One-click clear all history
- Automatic pruning to 50 most recent searches
- No sensitive metadata stored (only query and timestamp)

## Test Plan
- [x] Perform searches on Discover page
- [x] Verify searches appear in Header search overlay
- [x] Verify searches appear in Discover page dropdown
- [x] Toggle search history preference in Settings
- [x] Clear history and verify it's removed
- [x] Verify RLS prevents cross-user access
- [x] Build passes successfully

## Files Changed
- `supabase/migrations/011_create_search_history.sql` - Database table
- `supabase/migrations/012_add_search_history_enabled.sql` - User preference
- `src/app/api/search-history/route.ts` - New API endpoint
- `src/app/api/users/profile/route.ts` - Add preference handling
- `src/components/Header.tsx` - Search history integration
- `src/app/discover/page.tsx` - Search history integration
- `src/app/settings/page.tsx` - Settings controls

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-user book search history with recent searches in Header and Discover, plus settings to disable or clear. Privacy-first with RLS and auto-pruning to the last 50 searches.

- **New Features**
  - Database: search_history table + search_history_enabled user pref with RLS; keep last 50.
  - API: GET/POST/DELETE /api/search-history; PATCH /api/users/profile supports searchHistoryEnabled.
  - UI: Header shows last 5; Discover shows 10 on focus; Settings toggle and Clear All.
  - Behavior: POST is a no-op when disabled; empty state when no history.

- **Migration**
  - Run Supabase migrations 011_create_search_history and 012_add_search_history_enabled.

<sup>Written for commit 6925279a07f63e71d54f6be9edea2f2910e6ea9c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

