### PR TITLE
Add date filter to My Books section (#10)

### DIFF
--- a/src/app/my-books/page.tsx
+++ b/src/app/my-books/page.tsx
@@ -103,10 +103,11 @@ export default function MyBooksPage() {
       );
     }
 
-    // Filter by year (only on READ tab)
+    // Filter by year (only on READ tab, based on Date Finished)
     if (selectedShelf === 'READ' && selectedYear !== 'all') {
       filtered = filtered.filter(book => {
-        const bookYear = new Date(book.created_at).getFullYear().toString();
+        if (!book.completed_at) return false;
+        const bookYear = new Date(book.completed_at).getFullYear().toString();
         return bookYear === selectedYear;
       });
     }
@@ -211,11 +212,11 @@ export default function MyBooksPage() {
      }
    };
 
-  // Get unique years from READ books only (based on actual data)
-  const readBooks = userBooks.filter(book => book.status === 'READ');
+  // Get unique years from READ books only (based on Date Finished)
+  const readBooks = userBooks.filter(book => book.status === 'READ' && book.completed_at);
   const availableYears = Array.from(
     new Set(
-      readBooks.map(book => new Date(book.created_at).getFullYear())
+      readBooks.map(book => new Date(book.completed_at!).getFullYear())
     )
   ).sort((a, b) => b - a); // Most recent first
 


### PR DESCRIPTION
## Summary
Implements issue #10 - Add filter by date for 'My Books' section with improved dropdown styling and year filtering.

## Features Implemented
- ✅ Date sorting: "Newest First" and "Oldest First" options
- ✅ Year filter: Filter READ books by the year they were finished
- ✅ Improved dropdown styling with theme colors
- ✅ Custom chevron icons positioned properly
- ✅ Works seamlessly with existing filters

## Changes

### Sort Options
Added two new date sorting options to the sort dropdown:
- **Newest First** (default) - Shows most recently added books first
- **Oldest First** - Shows oldest books first

### Year Filter
- Appears only on the **Read** tab
- Shows years based on when books were finished (`completed_at`)
- Automatically populated with years from user's read books
- "All Years" option to show all read books
- Filter resets when switching away from Read tab

### UI Improvements
All dropdowns now feature:
- Teal border (`#018283`) matching app theme
- Custom ChevronDown icons in teal color
- Proper padding and positioning
- Consistent styling across all filters
- Better visual hierarchy

## UI Demo
**Before:** Generic gray dropdowns with default arrows far from text
**After:** Themed teal dropdowns with custom positioned icons

## Files Modified
- `src/app/my-books/page.tsx`:
  - Added date sorting (ascending/descending)
  - Added year filter state and logic
  - Improved dropdown styling
  - Filter based on completion date for year filter

## Test Plan
- [x] Sort by Newest First and Oldest First
- [x] Year filter appears only on Read tab
- [x] Year filter shows correct years from read books
- [x] Filter by specific year works correctly
- [x] Year filter resets when switching tabs
- [x] All dropdowns styled consistently
- [x] TypeScript compilation passes

## Technical Details
- Year filter uses `completed_at` field (Date Finished)
- Only includes books with completion dates
- Years sorted in descending order (most recent first)
- Filter logic only applies on READ shelf

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds date sorting and a year filter to My Books so users can find recent additions and filter Read books by when they were finished. Implements Linear issue #10.

- **New Features**
  - Sort by Newest First (default) or Oldest First.
  - Year filter on the Read tab, based on completed_at, shows only years with finished books; includes “All Years” and resets when leaving Read.
  - Updated dropdowns with teal theme and custom chevrons; consistent styling across filters.

<sup>Written for commit 6498940e5736ca4516102e8987c24ebc7d29ff65. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

