### PR TITLE
Change default shelf to Read list

### DIFF
--- a/src/app/my-shelf/page.tsx
+++ b/src/app/my-shelf/page.tsx
@@ -35,7 +35,7 @@ export default function MyBooksPage() {
   const [userBooks, setUserBooks] = useState<UserBook[]>([]);
   const [filteredBooks, setFilteredBooks] = useState<UserBook[]>([]);
   const [loading, setLoading] = useState(true);
-  const [selectedShelf, setSelectedShelf] = useState('WANT_TO_READ');
+  const [selectedShelf, setSelectedShelf] = useState('READ');
   const [searchTerm, setSearchTerm] = useState('');
   const [sortBy, setSortBy] = useState('date-added-desc');
   const [openDropdownId, setOpenDropdownId] = useState<string | null>(null);


### PR DESCRIPTION
## Summary
Changes the default shelf view in My Shelf page from "Want to Read" to "Read" list.

## Changes
- Updated `selectedShelf` initial state from `'WANT_TO_READ'` to `'READ'`

## Behavior
When users navigate to `/my-shelf`, they now see their "Read" books by default instead of their "Want to Read" books.

## Test Plan
- [x] Navigate to My Shelf page
- [x] Verify "Read" tab is active by default
- [x] Verify Read books are displayed
- [x] Verify other tabs still work when clicked

## Related Issues
Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the My Shelf default tab to Read instead of Want to Read. Users navigating to /my-shelf now see their Read books by default.

<sup>Written for commit 88f614a9426c4bddf2db4eabacd0e38a149a4533. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

