### PR TITLE
Fix missing book covers with fallback sources (#1)

### DIFF
--- a/src/__tests__/lib/book-sources.test.ts
+++ b/src/__tests__/lib/book-sources.test.ts
@@ -165,7 +165,7 @@ describe('Book Search Utilities', () => {
           title: 'Test Book',
           author: 'Unknown Author',
           isbn: undefined,
-          coverUrl: undefined,
+          coverUrl: null,
           publishedDate: undefined,
           pageCount: undefined,
           description: undefined,
@@ -236,7 +236,8 @@ describe('Book Search Utilities', () => {
         },
       };
 
-      mockedAxiosGet.mockResolvedValueOnce(googleResponse);
+      // First call: Google Books search. Second call: Open Library fallback cover search (no ISBN/cover).
+      mockedAxiosGet.mockResolvedValueOnce(googleResponse).mockResolvedValueOnce({ data: { docs: [] } });
 
       const result = await searchBooks('test query');
 
@@ -245,15 +246,12 @@ describe('Book Search Utilities', () => {
           title: 'Google Book',
           author: 'Google Author',
           isbn: undefined,
-          coverUrl: undefined,
+          coverUrl: null,
           publishedDate: undefined,
           pageCount: undefined,
           description: undefined,
         },
       ]);
-
-      // Should not call Open Library API
-      expect(mockedAxiosGet).toHaveBeenCalledTimes(1);
     });
 
     it('falls back to Open Library when Google Books returns no results', async () => {
@@ -276,7 +274,8 @@ describe('Book Search Utilities', () => {
 
       mockedAxiosGet
         .mockResolvedValueOnce(googleResponse)
-        .mockResolvedValueOnce(openLibraryResponse);
+        .mockResolvedValueOnce(openLibraryResponse)
+        .mockResolvedValueOnce({ data: { docs: [] } }); // fallback cover search
 
       const result = await searchBooks('test query');
 
@@ -292,8 +291,8 @@ describe('Book Search Utilities', () => {
         },
       ]);
 
-      // Should call both APIs
-      expect(mockedAxiosGet).toHaveBeenCalledTimes(2);
+      // Google Books search + Open Library search + fallback cover search
+      expect(mockedAxiosGet).toHaveBeenCalledTimes(3);
     });
 
     it('returns empty array when both APIs fail', async () => {

--- a/src/app/api/cover-fallback/route.ts
+++ b/src/app/api/cover-fallback/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { findBookCover } from '@/lib/data-sources/book-sources';
+
+export async function GET(request: NextRequest) {
+  const isbn = request.nextUrl.searchParams.get('isbn');
+  const title = request.nextUrl.searchParams.get('title');
+  const author = request.nextUrl.searchParams.get('author');
+
+  if (!isbn && !title) {
+    return NextResponse.json({ error: 'ISBN or title is required' }, { status: 400 });
+  }
+
+  try {
+    const coverUrl = await findBookCover(isbn || undefined, title || undefined, author || undefined);
+    return NextResponse.json({ coverUrl });
+  } catch (error) {
+    console.error('Cover fallback error:', error);
+    return NextResponse.json({ coverUrl: null });
+  }
+}

--- a/src/app/books/[id]/page.tsx
+++ b/src/app/books/[id]/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import { BookOpen, Star, Plus, CheckCircle } from 'lucide-react';
+import BookCoverImage from '@/components/BookCoverImage';
 
 interface Book {
   id: string;
@@ -310,17 +311,16 @@ export default function BookDetailPage({ params }: { params: Promise<{ id: strin
         <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
           {/* Book Cover */}
           <div className="md:col-span-1">
-            {book.coverUrl ? (
-              <img
-                src={book.coverUrl}
-                alt={book.title}
-                className="w-full max-w-md mx-auto rounded-lg shadow-lg"
-              />
-            ) : (
-              <div className="w-full max-w-md mx-auto bg-gray-200 rounded-lg shadow-lg flex items-center justify-center">
-                <BookOpen className="h-24 w-24 text-gray-400" />
-              </div>
-            )}
+            <BookCoverImage
+              src={book.coverUrl}
+              isbn={book.isbn}
+              title={book.title}
+              author={book.author}
+              alt={book.title}
+              className="w-full max-w-md mx-auto rounded-lg shadow-lg"
+              placeholderClassName="w-full max-w-md mx-auto bg-gray-200 rounded-lg shadow-lg flex items-center justify-center aspect-[3/4]"
+              iconClassName="h-24 w-24 text-gray-400"
+            />
 
             {user && (
               <div className="mt-6 space-y-4">

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -28,6 +28,7 @@ interface Book {
   title: string;
   author: string;
   cover?: string;
+  isbn?: string;
   rating?: number;
   status: 'WANT_TO_READ' | 'CURRENTLY_READING' | 'READ';
   progress?: number;
@@ -169,6 +170,7 @@ export default function Dashboard() {
             title: b.books?.title || b.title,
             author: b.books?.author || b.author,
             cover: b.books?.cover_url || b.cover_url,
+            isbn: b.books?.isbn || b.isbn,
             rating: b.rating,
             status: b.status,
             progress: b.progress,

--- a/src/app/discover/page.tsx
+++ b/src/app/discover/page.tsx
@@ -6,6 +6,7 @@ import { BookOpen, Star, Plus, TrendingUp, Users, Search, Filter, X, Sparkles, C
 import Link from 'next/link';
 import { useAuth } from '@/contexts/AuthContext';
 import { supabase } from '@/lib/supabase/client';
+import BookCoverImage from '@/components/BookCoverImage';
 
 interface Book {
   id?: string;
@@ -586,20 +587,16 @@ export default function DiscoverPage() {
                     {/* Front of card */}
                     <div className="relative bg-white/80 backdrop-blur-sm rounded-3xl overflow-hidden shadow-lg hover:shadow-2xl transition-all duration-300 hover:-translate-y-2 border border-gray-100" style={{ backfaceVisibility: 'hidden' }}>
                     <div className="aspect-[3/4] bg-gradient-to-br from-gray-100 to-gray-200 relative overflow-hidden">
-                      {book.coverUrl || book.cover_url ? (
-                        <img
-                          src={book.coverUrl || book.cover_url}
-                          alt={book.title}
-                          className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
-                        />
-                      ) : (
-                        <div className="w-full h-full flex items-center justify-center">
-                          <div className="relative">
-                            <BookOpen className="h-16 w-16 text-gray-400" />
-                            <div className="absolute inset-0 bg-gray-200 rounded-full blur-xl"></div>
-                          </div>
-                        </div>
-                      )}
+                      <BookCoverImage
+                        src={book.coverUrl || book.cover_url}
+                        isbn={book.isbn}
+                        title={book.title}
+                        author={book.author}
+                        alt={book.title}
+                        className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
+                        placeholderClassName="w-full h-full flex items-center justify-center"
+                        iconClassName="h-16 w-16 text-gray-400"
+                      />
                       <div className="absolute inset-0 bg-gradient-to-t from-black/20 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
                     </div>
 
@@ -782,20 +779,16 @@ export default function DiscoverPage() {
                     {/* Front of card */}
                     <div className="relative bg-white/80 backdrop-blur-sm rounded-3xl overflow-hidden shadow-lg hover:shadow-2xl transition-all duration-300 hover:-translate-y-2 border border-gray-100" style={{ backfaceVisibility: 'hidden' }}>
                     <div className="aspect-[3/4] bg-gradient-to-br from-gray-100 to-gray-200 relative overflow-hidden">
-                      {book.coverUrl || book.cover_url ? (
-                        <img
-                          src={book.coverUrl || book.cover_url}
-                          alt={book.title}
-                          className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
-                        />
-                      ) : (
-                        <div className="w-full h-full flex items-center justify-center">
-                          <div className="relative">
-                            <BookOpen className="h-16 w-16 text-gray-400" />
-                            <div className="absolute inset-0 bg-gray-200 rounded-full blur-xl"></div>
-                          </div>
-                        </div>
-                      )}
+                      <BookCoverImage
+                        src={book.coverUrl || book.cover_url}
+                        isbn={book.isbn}
+                        title={book.title}
+                        author={book.author}
+                        alt={book.title}
+                        className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
+                        placeholderClassName="w-full h-full flex items-center justify-center"
+                        iconClassName="h-16 w-16 text-gray-400"
+                      />
                       <div className="absolute top-3 right-3 bg-orange-500 text-white px-2 py-1 rounded-full text-xs font-bold shadow-lg">
                         #{index + 1}
                       </div>
@@ -975,20 +968,16 @@ export default function DiscoverPage() {
                     {/* Front of card */}
                     <div className="relative bg-white/80 backdrop-blur-sm rounded-3xl shadow-lg hover:shadow-2xl transition-all duration-300 hover:-translate-y-3 border border-gray-100" style={{ backfaceVisibility: 'hidden' }}>
                     <div className="aspect-[3/4] bg-gradient-to-br from-gray-100 to-gray-200 relative overflow-hidden">
-                      {book.coverUrl ? (
-                        <img
-                          src={book.coverUrl}
-                          alt={book.title}
-                          className="w-full h-full object-cover group-hover:scale-110 transition-transform duration-700"
-                        />
-                      ) : (
-                        <div className="w-full h-full flex items-center justify-center">
-                          <div className="relative">
-                            <BookOpen className="h-20 w-20 text-gray-400" />
-                            <div className="absolute inset-0 bg-gradient-to-br from-gray-200 to-gray-300 rounded-full blur-2xl"></div>
-                          </div>
-                        </div>
-                      )}
+                      <BookCoverImage
+                        src={book.coverUrl}
+                        isbn={book.isbn}
+                        title={book.title}
+                        author={book.author}
+                        alt={book.title}
+                        className="w-full h-full object-cover group-hover:scale-110 transition-transform duration-700"
+                        placeholderClassName="w-full h-full flex items-center justify-center"
+                        iconClassName="h-20 w-20 text-gray-400"
+                      />
                       <div className="absolute inset-0 bg-gradient-to-t from-black/40 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
                     </div>
 

--- a/src/app/import-books/page.tsx
+++ b/src/app/import-books/page.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import Link from 'next/link';
 import { Upload, CheckCircle2, XCircle, Loader, BookOpen, Download } from 'lucide-react';
+import BookCoverImage from '@/components/BookCoverImage';
 
 interface ParsedBook {
   name: string;
@@ -372,17 +373,15 @@ export default function ImportBooksPage() {
                 >
                   <div className="flex gap-3">
                     <div className="flex-shrink-0 w-16">
-                      {book.coverUrl ? (
-                        <img
-                          src={book.coverUrl}
-                          alt={book.name}
-                          className="w-16 h-24 object-cover rounded"
-                        />
-                      ) : (
-                        <div className="w-16 h-24 bg-gray-200 rounded flex items-center justify-center">
-                          <BookOpen className="w-6 h-6 text-gray-400" />
-                        </div>
-                      )}
+                      <BookCoverImage
+                        src={book.coverUrl}
+                        title={book.name}
+                        author={book.author}
+                        alt={book.name}
+                        className="w-16 h-24 object-cover rounded"
+                        placeholderClassName="w-16 h-24 bg-gray-200 rounded flex items-center justify-center"
+                        iconClassName="w-6 h-6 text-gray-400"
+                      />
                     </div>
 
                     <div className="flex-1 min-w-0">

--- a/src/app/my-shelf/page.tsx
+++ b/src/app/my-shelf/page.tsx
@@ -5,6 +5,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { supabase } from '@/lib/supabase/client';
 import Link from 'next/link';
 import { BookOpen, Star, Trash2, Edit2, Search, ChevronDown, BookMarked, Circle, CheckCircle, Clock, XCircle, Star as StarIcon, ChevronLeft, ChevronRight } from 'lucide-react';
+import BookCoverImage from '@/components/BookCoverImage';
 
 interface Book {
   id: string;
@@ -415,17 +416,18 @@ export default function MyBooksPage() {
                            href={`/books/${userBook.books?.isbn || userBook.book_id}`}
                            className="text-[#018283] hover:underline font-medium flex items-center gap-3"
                          >
-                           {userBook.books?.cover_url ? (
-                             <img
-                               src={userBook.books.cover_url}
-                               alt={userBook.books.title}
+                           <div className="w-8 h-12 rounded overflow-hidden flex-shrink-0">
+                             <BookCoverImage
+                               src={userBook.books?.cover_url}
+                               isbn={userBook.books?.isbn}
+                               title={userBook.books?.title}
+                               author={userBook.books?.author}
+                               alt={userBook.books?.title || ''}
                                className="w-8 h-12 object-cover rounded"
+                               placeholderClassName="w-8 h-12 bg-gray-200 rounded flex items-center justify-center"
+                               iconClassName="w-4 h-4 text-gray-400"
                              />
-                           ) : (
-                             <div className="w-8 h-12 bg-gray-200 rounded flex items-center justify-center flex-shrink-0">
-                               <BookOpen className="w-4 h-4 text-gray-400" />
-                             </div>
-                           )}
+                           </div>
                            <span>{userBook.books?.title}</span>
                          </Link>
                        </td>

--- a/src/app/recommendations/page.tsx
+++ b/src/app/recommendations/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import Link from 'next/link';
 import { Flame, Sparkles, Loader, BookOpen } from 'lucide-react';
+import BookCoverImage from '@/components/BookCoverImage';
 
 interface Book {
   id: string;
@@ -92,17 +93,15 @@ export default function RecommendationsPage() {
                       className="group bg-white rounded-lg shadow-sm hover:shadow-lg border border-gray-200 overflow-hidden transition-all duration-300"
                     >
                       <div className="relative h-48 bg-gray-200 overflow-hidden">
-                        {book.cover_url || book.coverUrl ? (
-                          <img
-                            src={book.cover_url || book.coverUrl}
-                            alt={book.title}
-                            className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
-                          />
-                        ) : (
-                          <div className="w-full h-full flex items-center justify-center bg-gray-300">
-                            <BookOpen className="h-12 w-12 text-gray-400" />
-                          </div>
-                        )}
+                        <BookCoverImage
+                          src={book.cover_url || book.coverUrl}
+                          title={book.title}
+                          author={book.author}
+                          alt={book.title}
+                          className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+                          placeholderClassName="w-full h-full flex items-center justify-center bg-gray-300"
+                          iconClassName="h-12 w-12 text-gray-400"
+                        />
                       </div>
                       <div className="p-4">
                         <h3 className="font-semibold text-gray-900 line-clamp-2 group-hover:text-[#018283]">{book.title}</h3>
@@ -150,17 +149,15 @@ export default function RecommendationsPage() {
                       className="group bg-white rounded-lg shadow-sm hover:shadow-lg border border-gray-200 overflow-hidden transition-all duration-300"
                     >
                       <div className="relative h-48 bg-gray-200 overflow-hidden">
-                        {book.cover_url || book.coverUrl ? (
-                          <img
-                            src={book.cover_url || book.coverUrl}
-                            alt={book.title}
-                            className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
-                          />
-                        ) : (
-                          <div className="w-full h-full flex items-center justify-center bg-gray-300">
-                            <BookOpen className="h-12 w-12 text-gray-400" />
-                          </div>
-                        )}
+                        <BookCoverImage
+                          src={book.cover_url || book.coverUrl}
+                          title={book.title}
+                          author={book.author}
+                          alt={book.title}
+                          className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+                          placeholderClassName="w-full h-full flex items-center justify-center bg-gray-300"
+                          iconClassName="h-12 w-12 text-gray-400"
+                        />
                         <div className="absolute top-2 right-2 bg-orange-500 text-white px-2 py-1 rounded text-xs font-semibold">
                           #{index + 1}
                         </div>

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -6,6 +6,7 @@ import { BookOpen, Star, Plus, TrendingUp, Users, Search, Filter, X, Sparkles, C
 import Link from 'next/link';
 import { useAuth } from '@/contexts/AuthContext';
 import { supabase } from '@/lib/supabase/client';
+import BookCoverImage from '@/components/BookCoverImage';
 
 interface Book {
   title: string;
@@ -513,20 +514,16 @@ export default function SearchPage() {
                 <div key={index} className="group cursor-pointer">
                   <div className="relative bg-white/80 backdrop-blur-sm rounded-3xl overflow-hidden shadow-lg hover:shadow-2xl transition-all duration-300 hover:-translate-y-2 border border-gray-100">
                     <div className="aspect-[3/4] bg-gradient-to-br from-gray-100 to-gray-200 relative overflow-hidden">
-                      {book.coverUrl ? (
-                        <img
-                          src={book.coverUrl}
-                          alt={book.title}
-                          className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
-                        />
-                      ) : (
-                        <div className="w-full h-full flex items-center justify-center">
-                          <div className="relative">
-                            <BookOpen className="h-16 w-16 text-gray-400" />
-                            <div className="absolute inset-0 bg-gray-200 rounded-full blur-xl"></div>
-                          </div>
-                        </div>
-                      )}
+                      <BookCoverImage
+                        src={book.coverUrl}
+                        isbn={book.isbn}
+                        title={book.title}
+                        author={book.author}
+                        alt={book.title}
+                        className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
+                        placeholderClassName="w-full h-full flex items-center justify-center"
+                        iconClassName="h-16 w-16 text-gray-400"
+                      />
                       <div className="absolute inset-0 bg-gradient-to-t from-black/20 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
                     </div>
                     
@@ -640,20 +637,16 @@ export default function SearchPage() {
                 <div key={index} className="group">
                   <div className="relative bg-white/80 backdrop-blur-sm rounded-3xl overflow-hidden shadow-lg hover:shadow-2xl transition-all duration-300 hover:-translate-y-3 border border-gray-100">
                     <div className="aspect-[3/4] bg-gradient-to-br from-gray-100 to-gray-200 relative overflow-hidden">
-                      {book.coverUrl ? (
-                        <img
-                          src={book.coverUrl}
-                          alt={book.title}
-                          className="w-full h-full object-cover group-hover:scale-110 transition-transform duration-700"
-                        />
-                      ) : (
-                        <div className="w-full h-full flex items-center justify-center">
-                          <div className="relative">
-                            <BookOpen className="h-20 w-20 text-gray-400" />
-                            <div className="absolute inset-0 bg-gradient-to-br from-gray-200 to-gray-300 rounded-full blur-2xl"></div>
-                          </div>
-                        </div>
-                      )}
+                      <BookCoverImage
+                        src={book.coverUrl}
+                        isbn={book.isbn}
+                        title={book.title}
+                        author={book.author}
+                        alt={book.title}
+                        className="w-full h-full object-cover group-hover:scale-110 transition-transform duration-700"
+                        placeholderClassName="w-full h-full flex items-center justify-center"
+                        iconClassName="h-20 w-20 text-gray-400"
+                      />
                       <div className="absolute inset-0 bg-gradient-to-t from-black/40 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
                     </div>
                     

--- a/src/components/BookCard.tsx
+++ b/src/components/BookCard.tsx
@@ -1,10 +1,14 @@
+'use client';
+
 import { BookOpen, Star } from 'lucide-react';
+import BookCoverImage from '@/components/BookCoverImage';
 
 interface Book {
   id: string;
   title: string;
   author: string;
   cover?: string;
+  isbn?: string;
   rating?: number;
   status: 'WANT_TO_READ' | 'CURRENTLY_READING' | 'READ' | 'DNF';
   progress?: number;
@@ -21,15 +25,19 @@ export default function BookCard({ book, variant = 'list', onClick }: BookCardPr
     return (
       <div onClick={onClick} className="group cursor-pointer">
         <div className="relative mb-3 overflow-hidden rounded-lg shadow-sm group-hover:shadow-md transition-shadow">
-          {book.cover ? (
-            <div className="aspect-[3/4] bg-gray-200 flex items-center justify-center">
-              <img src={book.cover} alt={book.title} className="w-full h-full object-cover" />
-            </div>
-          ) : (
-            <div data-testid="book-placeholder" className="aspect-[3/4] bg-gradient-to-br from-gray-300 to-gray-400 flex items-center justify-center">
-              <BookOpen className="h-8 w-8 text-white/60" />
-            </div>
-          )}
+          <div className="aspect-[3/4] bg-gray-200 flex items-center justify-center">
+            <BookCoverImage
+              src={book.cover}
+              isbn={book.isbn}
+              title={book.title}
+              author={book.author}
+              alt={book.title}
+              className="w-full h-full object-cover"
+              placeholderClassName="aspect-[3/4] w-full bg-gradient-to-br from-gray-300 to-gray-400 flex items-center justify-center"
+              placeholderTestId="book-placeholder"
+              iconClassName="h-8 w-8 text-white/60"
+            />
+          </div>
         </div>
         <h4 className="font-medium text-gray-900 text-sm line-clamp-2 mb-1">
           {book.title}
@@ -56,18 +64,20 @@ export default function BookCard({ book, variant = 'list', onClick }: BookCardPr
   return (
     <div onClick={onClick} className="flex items-start space-x-4 p-4 bg-gray-50 rounded-xl hover:bg-gray-100 transition-colors cursor-pointer border border-gray-200">
       <div className="flex-shrink-0 relative">
-        {book.cover ? (
-          <div className="w-12 h-18 bg-gray-200 rounded-lg flex items-center justify-center shadow-sm">
-            <img src={book.cover} alt={book.title} className="w-full h-full object-cover rounded-lg" />
-          </div>
-        ) : (
-          <div data-testid="book-placeholder-list" className="w-12 h-18 bg-gradient-to-br from-gray-300 to-gray-400 rounded-lg flex items-center justify-center shadow-sm">
-            <BookOpen className="h-6 w-6 text-white/80" />
-          </div>
-        )}
+        <div className="w-12 h-18 bg-gray-200 rounded-lg flex items-center justify-center shadow-sm">
+          <BookCoverImage
+            src={book.cover}
+            isbn={book.isbn}
+            alt={book.title}
+            className="w-full h-full object-cover rounded-lg"
+            placeholderClassName="w-12 h-18 bg-gradient-to-br from-gray-300 to-gray-400 rounded-lg flex items-center justify-center shadow-sm"
+            placeholderTestId="book-placeholder-list"
+            iconClassName="h-6 w-6 text-white/80"
+          />
+        </div>
         {book.status === 'CURRENTLY_READING' && book.progress && (
           <div className="absolute -bottom-1 left-0 right-0 h-1 bg-gray-200 rounded-full overflow-hidden">
-            <div 
+            <div
               className="h-full bg-teal-600 rounded-full transition-all duration-300"
               style={{ width: `${book.progress}%` }}
             />

--- a/src/components/BookCard.tsx
+++ b/src/components/BookCard.tsx
@@ -68,6 +68,8 @@ export default function BookCard({ book, variant = 'list', onClick }: BookCardPr
           <BookCoverImage
             src={book.cover}
             isbn={book.isbn}
+            title={book.title}
+            author={book.author}
             alt={book.title}
             className="w-full h-full object-cover rounded-lg"
             placeholderClassName="w-12 h-18 bg-gradient-to-br from-gray-300 to-gray-400 rounded-lg flex items-center justify-center shadow-sm"

--- a/src/components/BookCoverImage.tsx
+++ b/src/components/BookCoverImage.tsx
@@ -67,6 +67,7 @@ export default function BookCoverImage({
 
   const handleImgError = () => {
     if (!imgBroken) {
+      // Original src failed — try fallback
       setImgBroken(true);
       if ((isbn || title) && fetchKey !== currentKey) {
         setFetchKey(currentKey);
@@ -75,6 +76,9 @@ export default function BookCoverImage({
           .then(data => setFallbackUrl(data.coverUrl || null))
           .catch(() => setFallbackUrl(null));
       }
+    } else {
+      // Fallback image also failed — clear it so placeholder renders
+      setFallbackUrl(null);
     }
   };
 

--- a/src/components/BookCoverImage.tsx
+++ b/src/components/BookCoverImage.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { BookOpen } from 'lucide-react';
+
+interface BookCoverImageProps {
+  src?: string | null;
+  isbn?: string | null;
+  title?: string | null;
+  author?: string | null;
+  alt: string;
+  className?: string;
+  placeholderClassName?: string;
+  placeholderTestId?: string;
+  iconClassName?: string;
+}
+
+function buildFallbackUrl(isbn?: string | null, title?: string | null, author?: string | null): string {
+  const params = new URLSearchParams();
+  if (isbn) params.set('isbn', isbn);
+  if (title) params.set('title', title);
+  if (author) params.set('author', author);
+  return `/api/cover-fallback?${params.toString()}`;
+}
+
+export default function BookCoverImage({
+  src,
+  isbn,
+  title,
+  author,
+  alt,
+  className = 'w-full h-full object-cover',
+  placeholderClassName = 'w-full h-full bg-gradient-to-br from-gray-300 to-gray-400 flex items-center justify-center',
+  placeholderTestId,
+  iconClassName = 'h-6 w-6 text-white/60',
+}: BookCoverImageProps) {
+  const [fallbackUrl, setFallbackUrl] = useState<string | null>(null);
+  const [imgBroken, setImgBroken] = useState(false);
+  const [fetchKey, setFetchKey] = useState<string | null>(null);
+
+  const currentKey = `${isbn || ''}|${title || ''}`;
+
+  // Fetch fallback cover when there's no src (or src broke) and we have ISBN or title
+  useEffect(() => {
+    if (src) {
+      setFallbackUrl(null);
+      setImgBroken(false);
+      setFetchKey(null);
+      return;
+    }
+
+    if ((isbn || title) && fetchKey !== currentKey) {
+      setFetchKey(currentKey);
+      let cancelled = false;
+      fetch(buildFallbackUrl(isbn, title, author))
+        .then(res => res.json())
+        .then(data => {
+          if (!cancelled) setFallbackUrl(data.coverUrl || null);
+        })
+        .catch(() => {
+          if (!cancelled) setFallbackUrl(null);
+        });
+      return () => { cancelled = true; };
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [src, isbn, title, author]);
+
+  const handleImgError = () => {
+    if (!imgBroken) {
+      setImgBroken(true);
+      if ((isbn || title) && fetchKey !== currentKey) {
+        setFetchKey(currentKey);
+        fetch(buildFallbackUrl(isbn, title, author))
+          .then(res => res.json())
+          .then(data => setFallbackUrl(data.coverUrl || null))
+          .catch(() => setFallbackUrl(null));
+      }
+    }
+  };
+
+  const displayUrl = (!imgBroken && src) ? src : fallbackUrl;
+
+  if (displayUrl) {
+    return (
+      <img
+        src={displayUrl}
+        alt={alt}
+        className={className}
+        onError={handleImgError}
+      />
+    );
+  }
+
+  return (
+    <div data-testid={placeholderTestId} className={placeholderClassName}>
+      <BookOpen className={iconClassName} />
+    </div>
+  );
+}

--- a/src/components/BookCoverImage.tsx
+++ b/src/components/BookCoverImage.tsx
@@ -38,7 +38,7 @@ export default function BookCoverImage({
   const [imgBroken, setImgBroken] = useState(false);
   const [fetchKey, setFetchKey] = useState<string | null>(null);
 
-  const currentKey = `${isbn || ''}|${title || ''}`;
+  const currentKey = `${isbn || ''}|${title || ''}|${author || ''}`;
 
   // Fetch fallback cover when there's no src (or src broke) and we have ISBN or title
   useEffect(() => {

--- a/src/components/CheckinHistory.tsx
+++ b/src/components/CheckinHistory.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { BookOpen, Calendar, Trash2 } from 'lucide-react';
+import BookCoverImage from '@/components/BookCoverImage';
 
 interface Checkin {
   id: string;
@@ -110,17 +111,15 @@ export default function CheckinHistory({
                 className="flex items-start gap-4 p-4 bg-gray-50 rounded-xl border border-gray-100 hover:border-gray-200 transition-colors group"
               >
                 {/* Book Cover */}
-                {checkin.books?.cover_url ? (
-                  <img
-                    src={checkin.books.cover_url}
-                    alt={checkin.books.title}
-                    className="w-12 h-18 object-cover rounded-lg shadow-sm flex-shrink-0"
-                  />
-                ) : (
-                  <div className="w-12 h-18 bg-gray-200 rounded-lg flex items-center justify-center flex-shrink-0">
-                    <BookOpen className="h-5 w-5 text-gray-400" />
-                  </div>
-                )}
+                <BookCoverImage
+                  src={checkin.books?.cover_url}
+                  title={checkin.books?.title}
+                  author={checkin.books?.author}
+                  alt={checkin.books?.title || ''}
+                  className="w-12 h-18 object-cover rounded-lg shadow-sm flex-shrink-0"
+                  placeholderClassName="w-12 h-18 bg-gray-200 rounded-lg flex items-center justify-center flex-shrink-0"
+                  iconClassName="h-5 w-5 text-gray-400"
+                />
 
                 {/* Content */}
                 <div className="flex-1 min-w-0">

--- a/src/components/ReadingCheckinModal.tsx
+++ b/src/components/ReadingCheckinModal.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef, useEffect } from 'react';
 import { X, BookOpen, ChevronDown, Search, Loader2 } from 'lucide-react';
 import { supabase } from '@/lib/supabase/client';
+import BookCoverImage from '@/components/BookCoverImage';
 
 interface Book {
   id: string;
@@ -247,17 +248,15 @@ export default function ReadingCheckinModal({
               >
                 {selectedBook ? (
                   <div className="flex items-center gap-3">
-                    {selectedBook.cover_url ? (
-                      <img
-                        src={selectedBook.cover_url}
-                        alt={selectedBook.title}
-                        className="w-8 h-12 object-cover rounded"
-                      />
-                    ) : (
-                      <div className="w-8 h-12 bg-gray-200 rounded flex items-center justify-center">
-                        <BookOpen className="h-4 w-4 text-gray-400" />
-                      </div>
-                    )}
+                    <BookCoverImage
+                      src={selectedBook.cover_url}
+                      title={selectedBook.title}
+                      author={selectedBook.author}
+                      alt={selectedBook.title}
+                      className="w-8 h-12 object-cover rounded"
+                      placeholderClassName="w-8 h-12 bg-gray-200 rounded flex items-center justify-center"
+                      iconClassName="h-4 w-4 text-gray-400"
+                    />
                     <div className="min-w-0">
                       <p className="font-medium text-gray-900 truncate">{selectedBook.title}</p>
                       <p className="text-sm text-gray-500 truncate">{selectedBook.author}</p>
@@ -353,17 +352,15 @@ export default function ReadingCheckinModal({
                             }}
                             className="w-full flex items-center gap-3 px-4 py-3 hover:bg-gray-50 transition-colors text-left border-b border-gray-100 last:border-0"
                           >
-                            {book.cover_url ? (
-                              <img
-                                src={book.cover_url}
-                                alt={book.title}
-                                className="w-8 h-12 object-cover rounded"
-                              />
-                            ) : (
-                              <div className="w-8 h-12 bg-gray-200 rounded flex items-center justify-center">
-                                <BookOpen className="h-4 w-4 text-gray-400" />
-                              </div>
-                            )}
+                            <BookCoverImage
+                              src={book.cover_url}
+                              title={book.title}
+                              author={book.author}
+                              alt={book.title}
+                              className="w-8 h-12 object-cover rounded"
+                              placeholderClassName="w-8 h-12 bg-gray-200 rounded flex items-center justify-center"
+                              iconClassName="h-4 w-4 text-gray-400"
+                            />
                             <div className="min-w-0 flex-1">
                               <p className="font-medium text-gray-900 truncate">{book.title}</p>
                               <p className="text-sm text-gray-500 truncate">{book.author}</p>

--- a/src/lib/data-sources/book-sources.ts
+++ b/src/lib/data-sources/book-sources.ts
@@ -1,9 +1,46 @@
 import axios from 'axios';
 
+async function fetchCoverFromAbeBooks(isbn: string): Promise<string | null> {
+  try {
+    const url = `https://pictures.abebooks.com/isbn/${isbn}-us-300.jpg`;
+    const response = await axios.head(url);
+    if (response.status === 200) return url;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchCoverFromOpenLibrarySearch(title: string, author: string): Promise<string | null> {
+  try {
+    const query = `${title} ${author}`.trim();
+    const response = await axios.get(
+      `https://openlibrary.org/search.json?q=${encodeURIComponent(query)}&limit=1&fields=cover_i`
+    );
+    const coverId = response.data?.docs?.[0]?.cover_i;
+    if (!coverId) return null;
+    return `https://covers.openlibrary.org/b/id/${coverId}-L.jpg`;
+  } catch {
+    return null;
+  }
+}
+
+export async function findBookCover(isbn?: string, title?: string, author?: string): Promise<string | null> {
+  if (isbn) {
+    const abeCover = await fetchCoverFromAbeBooks(isbn);
+    if (abeCover) return abeCover;
+  }
+
+  if (title) {
+    return fetchCoverFromOpenLibrarySearch(title, author || '');
+  }
+  return null;
+}
+
 export async function searchBooksOpenLibrary(query: string, limit = 20) {
   try {
     const response = await axios.get(`https://openlibrary.org/search.json?q=${encodeURIComponent(query)}&limit=${limit}`);
-    return response.data.docs.map((book: any) => ({
+    const books = response.data.docs.map((book: any) => ({
       title: book.title,
       author: book.author_name?.[0] || 'Unknown Author',
       isbn: book.isbn?.[0],
@@ -12,6 +49,15 @@ export async function searchBooksOpenLibrary(query: string, limit = 20) {
       pageCount: book.number_of_pages_median,
       description: null, // Open Library doesn't typically provide descriptions
     }));
+    const results = await Promise.all(
+      books.map(async (book: any) => {
+        if (!book.coverUrl) {
+          book.coverUrl = await findBookCover(book.isbn, book.title, book.author);
+        }
+        return book;
+      })
+    );
+    return results;
   } catch (error) {
     console.error('Open Library search error:', error);
     return [];
@@ -24,15 +70,25 @@ export async function searchBooksGoogleAI(query: string, limit = 20) {
     if (!response.data.items || !Array.isArray(response.data.items)) {
       return [];
     }
-    return response.data.items.map((book: any) => ({
+    const books = response.data.items.map((book: any) => ({
       title: book.volumeInfo.title,
       author: book.volumeInfo.authors?.[0] || 'Unknown Author',
-      isbn: book.volumeInfo.industryIdentifiers?.find((id: any) => id.type === 'ISBN_13')?.identifier,
+      isbn: book.volumeInfo.industryIdentifiers?.find((id: any) => id.type === 'ISBN_13')?.identifier
+        || book.volumeInfo.industryIdentifiers?.find((id: any) => id.type === 'ISBN_10')?.identifier,
       coverUrl: book.volumeInfo.imageLinks?.thumbnail,
       publishedDate: book.volumeInfo.publishedDate,
       pageCount: book.volumeInfo.pageCount,
       description: book.volumeInfo.description,
     }));
+    const results = await Promise.all(
+      books.map(async (book: any) => {
+        if (!book.coverUrl) {
+          book.coverUrl = await findBookCover(book.isbn, book.title, book.author);
+        }
+        return book;
+      })
+    );
+    return results;
   } catch (error) {
     console.error('Google Books search error:', error);
     return [];


### PR DESCRIPTION
## Summary
- Added AbeBooks (ISBN lookup) and Open Library (title+author search) as fallback cover image sources when primary sources return no cover
- Created reusable `BookCoverImage` component that automatically fetches fallback covers client-side via `/api/cover-fallback` endpoint
- Replaced all raw `<img>` book cover rendering across 11 files with `BookCoverImage` so every book cover in the app benefits from fallback resolution
- Also extracts ISBN_10 as fallback when ISBN_13 is unavailable from Google Books

## Test plan
- [ ] Search for "freida mcfadden" — verify "The Housemaid Is Watching" now shows a cover
- [ ] Check my-shelf page for books previously missing covers
- [ ] Check book detail, recommendations, discover, import, and checkin pages for consistent cover display
- [ ] Verify books that already have covers still display correctly
- [ ] Verify broken cover URLs gracefully fall back instead of showing broken images

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing and broken book covers across the app by adding reliable fallback sources and a reusable image component. All cover slots now show a cover or a clean placeholder instead of broken images.

- **Bug Fixes**
  - Added AbeBooks (ISBN) and Open Library (title+author) fallbacks via /api/cover-fallback.
  - Introduced BookCoverImage component with automatic client-side fallback on missing/broken URLs; replaced raw img tags across the app.
  - Uses ISBN_13 or ISBN_10 when available; tries fallback sources if primary cover is absent.
  - Search data sources now populate covers with fallbacks when needed.
  - Applied in book detail, search, discover, my shelf, recommendations, dashboard, import, and check-ins.

<sup>Written for commit 52f0c0e8d608423129255ed9b0828a17ec54dba5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

